### PR TITLE
Add samples for pre-issue access token extension

### DIFF
--- a/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/README.md
+++ b/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/README.md
@@ -33,7 +33,7 @@ This function implements an adaptive token issuance policy using IP-based compli
 ## Features
 
 - Blocks access token issuance for restricted countries or regions
-- Evaluates IP risk scores using AbuseIPDB
+- Evaluates IP risk scores using [AbuseIPDB](https://www.abuseipdb.com/)
 - Dynamically adjusts token expiry time based on risk score and login time (UTC)
 - Allows tokens with full expiry only for low-risk IPs
 - Designed to run as an AWS Lambda function for easy deployment

--- a/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/README.md
+++ b/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/README.md
@@ -1,0 +1,209 @@
+# Adaptive Token Issuance Policy
+
+This is a Node.js-based AWS Lambda function that enforces an adaptive access token issuance policy. It blocks tokens from restricted countries and high-risk IP addresses, and dynamically adjusts token lifetimes based on IP reputation and login time.
+
+> **Note:** This sample is for demonstration only and should not be used in production. It supports the **Pre-issue access token action feature** of both [Asgardeo](https://console.asgardeo.io/) and [WSO2 Identity Server](https://wso2.com/identity-server/).
+
+## Table of Contents
+- [Overview](#overview)
+- [Features](#features)
+- [External Services Used](#external-services-used)
+- [Prerequisites](#prerequisites)
+- [Setup Instructions](#setup-instructions)
+  - [1️⃣ Clone the Repository](#1-clone-the-repository)
+  - [2️⃣ Install Dependencies](#2-install-dependencies)
+  - [3️⃣ Zip the Workspace](#3-zip-the-workspace)
+  - [4️⃣ Deploy Lambda Function on AWS](#4-create-lambda-function-on-AWS)
+    - [Create Lambda Function](#create-lambda-function)
+    - [Add Code and Dependencies](#add-code-and-dependencies)
+    - [Set Environmental Variables](#set-environmental-variables)
+    - [Enable a Function URL](#enable-a-function-url)
+- [Configure the Extension](#7-configure-the-extension)
+  - [1️⃣ Create an Appliction](#1-create-an-application)
+  - [2️⃣ Set Up Pre-Issue Access Token Action](#1-setup-pre-issue-access-token-action)
+- [Test Example Scenarios](#test-example-scenarios)
+
+## Overview
+
+This function implements an adaptive token issuance policy using IP-based compliance and risk analysis. It supports:
+
+- Blocking access tokens from restricted countries and high-risk IPs
+- Dynamic token expiry based on IP reputation and login time
+
+## Features
+
+- Blocks access token issuance for restricted countries or regions
+- Evaluates IP risk scores using AbuseIPDB
+- Dynamically adjusts token expiry time based on risk score and login time (UTC)
+- Allows tokens with full expiry only for low-risk IPs
+- Designed to run as an AWS Lambda function for easy deployment
+
+When a client requests an access token:
+
+1. **Geo Compliance Check**  
+   - The client's IP address is extracted from the request.
+   - If the IP belongs to a **restricted country/region** (e.g., North Korea, Iran, Russia), **token issuance is blocked**.
+
+2. **IP Risk Analysis (AbuseIPDB Integration)**  
+   - If the country is allowed, the IP address is checked against **AbuseIPDB** for its **abuse confidence score**.
+
+3. **Token Issuance Policy**  
+   Based on the AbuseIPDB score and the login time:
+   
+   - **Score ≥ 75** → Token issuance is **blocked** (high risk)
+   - **Score between 25 and 75**:
+     - During **working hours** (9AM–5PM UTC) → Token expiry = **15 minutes**
+     - Outside working hours → ⏳ Token expiry = **5 minutes**
+   - **Score < 25** → Token expiry = **1 hour**
+
+## External Services Used
+
+- **GeoIP Lookup**  
+  - Using [`geoip-country`](https://www.npmjs.com/package/geoip-country) Node.js library for offline IP-to-country resolution.
+
+- **AbuseIPDB Risk Scoring**  
+  - Using [AbuseIPDB](https://www.abuseipdb.com/) public API to retrieve the abuse confidence score for IP addresses.
+  - Requires an API key (`Key` header) to make risk score lookups.
+
+## Prerequisites
+
+- **Node.js** (>=14.x) – for local development and packaging
+- **npm** - to manage dependencies like `geoip-country`
+- An AWS Account with permission to create Lambda functions
+- AbuseIPDB API Key – for querying IP risk scores
+
+## Setup Instructions
+
+### 1. Clone the Repository
+
+```bash
+git clone https://github.com/asgardeo-samples/asgardeo-service-extension-samples.git
+cd pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda
+```
+
+[← Back to Table of Contents](#table-of-contents)
+
+### 2. Install Dependencies
+
+```bash
+npm install
+```
+[← Back to Table of Contents](#table-of-contents)
+
+### 3. Zip the Workspace
+
+Zip the entire workspace (including `index.mjs`, `node_modules`, and `package.json`):
+```bash
+zip -r function.zip .
+```
+
+[← Back to Table of Contents](#table-of-contents)
+
+### 4. Deploy Lambda Function on AWS
+
+### Create Lambda Function
+
+Go to the [AWS Lambda Console](https://console.aws.amazon.com/lambda/).
+
+Click **Create function** → **Author from scratch**.
+
+Provide the following details:
+- **Function name**: `adaptive-token-policy`
+- **Runtime**: `Node.js 18.x` (or the latest supported version).
+
+Click **Create function**.
+
+### Add Code and Dependencies
+
+Go to the **AWS Lambda Console**.
+
+Open your Lambda function (`adaptive-token-policy`).
+
+Click **Upload from** → **.zip file**.
+
+Upload the `function.zip` file you just created.
+
+Click **Deploy** to save the changes.
+
+### Set Environmental Variables
+
+Go to the **Configuration** tab → **Environment variables**.
+
+Add the following key-value pair:
+- **Key**: `ABUSEIPDB_API_KEY`
+- **Value**: Your AbuseIPDB API key.
+
+Click **Save**.
+
+### Enable a Function URL
+
+Go to the **Configuration** tab → **Function URL**.
+
+Click **Create function URL**.
+
+Set **Auth type** to `NONE` (or configure IAM if needed).
+
+Click **Save**.
+
+Note the **Function URL** (e.g., `https://<unique-id>.lambda-url.<region>.on.aws`).
+
+[← Back to Table of Contents](#table-of-contents)
+
+## Configure the Extension
+
+### 1. Create an Application
+
+Navigate to **Applications** → **New Application** in the Console application in Asgardeo or the WSO2 Identity Server.
+
+Select **Standard-Based Application**.
+
+Provide the following details:
+- **Name**: `Adaptive Token Policy Demo App`
+- **Protocol**: OpenID Connect
+- **Grant Types**: Enable `Authorization Code` and `Client Credentials`.
+
+Save the application.
+
+### 2. Set Up Pre-Issue Access Token Action
+
+Navigate to **Actions** → **Pre-Issue Access Token**.
+
+Create a new action:
+- **Action Name**: `Adaptive Token Policy`.
+- **Endpoint URL**: Paste the Lambda **Function URL** (e.g., `https://<unique-id>.lambda-url.<region>.on.aws`).
+
+Save the action.
+
+
+## Test Example Scenarios
+
+Use `curl` or Postman to simulate token requests with different IPs and observe the behavior.
+
+Replace placeholders with actual values:
+
+```bash
+curl -X POST https://api.asgardeo.io/t/<tenant>/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -H "x-client-source-ip: <client_ip>" \
+  -u "<client_id>:<client_secret>" \
+  -d "grant_type=authorization_code" \
+  -d "code=<authorization_code>" \
+  -d "redirect_uri=<redirect_uri>"
+```
+
+### Test Scenarios and Examples
+
+1. **Restricted Country**:  
+   The IP `175.45.176.0` belongs to a restricted country (North Korea). The request will be blocked.
+
+2. **High Abuse Score**:  
+   The IP `103.159.198.178` has an abuse confidence score > 75. The request will be blocked due to high risk.
+
+3. **Moderate Abuse Score (Working Hours)**:  
+   The IP `14.102.69.58` has an abuse confidence score in between 25 & 75. During working hours (9AM–5PM UTC), the token will be issued with a 15-minute expiry.
+
+4. **Moderate Abuse Score (Outside Working Hours)**:  
+   The IP `14.102.69.58` has an abuse confidence score in between 25 & 75. Outside working hours, the token will be issued with a 5-minute expiry.
+
+5. **Low Abuse Score**:  
+   The IP `205.210.31.51` has an abuse confidence score < 25. The token will be issued with a 1-hour expiry.

--- a/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/index.mjs
+++ b/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/index.mjs
@@ -1,0 +1,149 @@
+import https from "https";
+import geoip from "geoip-country";
+
+const BLOCKED_COUNTRIES = ["KP", "IR", "RU", "SY", "CN"];
+const ABUSEIPDB_API_KEY = process.env.ABUSEIPDB_API_KEY;
+const ABUSEIPDB_ENDPOINT = "https://api.abuseipdb.com/api/v2/check";
+
+const EXPIRY_WORKING_HOURS = 900; // 15 minutes
+const EXPIRY_NON_WORKING_HOURS = 300; // 5 minutes
+
+function getClientIp(event) {
+    try {
+        const body = JSON.parse(event.body);
+        const headers = body?.event?.request?.additionalHeaders || [];
+        const ipHeader = headers.find((h) => h.name.toLowerCase() === "x-client-source-ip");
+        return ipHeader?.value?.[0] || null;
+    } catch (e) {
+        console.warn("Failed to parse client IP:", e.message);
+        return null;
+    }
+}
+
+function lookupCountry(ip) {
+    const geo = geoip.lookup(ip);
+    return geo?.country || "UNKNOWN";
+}
+
+function callAbuseIPDB(ip) {
+    const url = `${ABUSEIPDB_ENDPOINT}?ipAddress=${ip}`;
+    const options = {
+        method: "GET",
+        headers: {
+            Key: ABUSEIPDB_API_KEY,
+            Accept: "application/json"
+        }
+    };
+
+    return new Promise((resolve, reject) => {
+        const req = https.request(url, options, (res) => {
+            let data = "";
+            res.on("data", (chunk) => data += chunk);
+            res.on("end", () => {
+                try {
+                    const parsed = JSON.parse(data);
+                    const score = parsed?.data?.abuseConfidenceScore ?? 0;
+                    resolve(score);
+                } catch (err) {
+                    reject(new Error("Failed to parse AbuseIPDB response"));
+                }
+            });
+        });
+
+        req.on("error", (err) => {
+            reject(err);
+        });
+
+        req.end();
+    });
+}
+
+function isWorkingHours() {
+    const hourUTC = new Date().getUTCHours();
+    return (hourUTC >= 9 && hourUTC < 17); // 9 AM - 5 PM UTC
+}
+
+export const handler = async (event) => {
+    console.log("Received event:", JSON.stringify(event, null, 2));
+
+    const ip = getClientIp(event);
+    if (!ip) {
+        console.warn("No IP address found. Denying the request by default.");
+        return denyResponse();
+    }
+
+    console.log(`Client IP: ${ip}`);
+
+    const country = lookupCountry(ip);
+    console.log(`Resolved country: ${country}`);
+
+    if (BLOCKED_COUNTRIES.includes(country)) {
+        console.log(`Blocked due to restricted country: ${country}`);
+        return denyResponse(`Access token issuance is blocked from your region (${country}).`);
+    }
+
+    try {
+        const abuseScore = await callAbuseIPDB(ip);
+        console.log(`Abuse Confidence Score: ${abuseScore}`);
+
+        if (abuseScore > 75) {
+            console.log(`Blocked due to high abuse score: ${abuseScore}`);
+            return denyResponse("Access token issuance is blocked due to high IP risk.");
+        }
+
+        if (abuseScore < 25) {
+            console.log(`Allowed token issuance: Low abuse score (${abuseScore}). No modifications applied.`);
+            return allowResponse();
+        }
+
+        // Determine expiry based on score and login time
+        let expiry;
+        if (isWorkingHours()) {
+            expiry = EXPIRY_WORKING_HOURS; // 15 mins for low risk during working hours
+        } else {
+            expiry = EXPIRY_NON_WORKING_HOURS; // 5 mins for low risk outside working hours
+        }
+
+        console.log(`Allowing token issuance with expiry: ${expiry} seconds`);
+
+        return {
+            statusCode: 200,
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+                actionStatus: "SUCCESS",
+                operations: [
+                    {
+                        op: "replace",
+                        path: "/accessToken/claims/expires_in",
+                        value: expiry.toString()
+                    }
+                ]
+            })
+        };
+    } catch (err) {
+        console.error("Error during AbuseIPDB lookup:", err.message);
+        return denyResponse();
+    }
+};
+
+function denyResponse(reason) {
+    return {
+        statusCode: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            actionStatus: "FAILED",
+            failureReason: "access_denied",
+            failureDescription: reason
+        })
+    };
+}
+
+function allowResponse() {
+    return {
+        statusCode: 200,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            actionStatus: "SUCCESS"
+        })
+    };
+}

--- a/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/package-lock.json
+++ b/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/package-lock.json
@@ -1,0 +1,130 @@
+{
+  "name": "adaptive-token-issuance-policy",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "adaptive-token-issuance-policy",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "geoip-country": "^5.0.202504292342"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/countries-list": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/countries-list/-/countries-list-3.1.1.tgz",
+      "integrity": "sha512-nPklKJ5qtmY5MdBKw1NiBAoyx5Sa7p2yPpljZyQ7gyCN1m+eMFs9I6CT37Mxt8zvR5L3VzD3DJBE4WQzX3WF4A=="
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/geoip-country": {
+      "version": "5.0.202504292342",
+      "resolved": "https://registry.npmjs.org/geoip-country/-/geoip-country-5.0.202504292342.tgz",
+      "integrity": "sha512-yBn8M7SQf4llpVJV2Apd+BJMcRzQiYsOpt4FC31hsjkP02IRTkm/tDrZAHOWsO3GnF1n43Lrsekd+HC3oBai1Q==",
+      "dependencies": {
+        "async": "^2.6.4",
+        "countries-list": "^3.1.1",
+        "ip-address": "^6.4.0",
+        "yauzl": "^2.10.0"
+      },
+      "engines": {
+        "node": ">=10.20.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-6.4.0.tgz",
+      "integrity": "sha512-c5uxc2WUTuRBVHT/6r4m7HIr/DfV0bF6DvLH3iZGSK8wp8iMwwZSgIq2do0asFf8q9ECug0SE+6+1ACMe4sorA==",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "lodash.find": "4.6.0",
+        "lodash.max": "4.0.1",
+        "lodash.merge": "4.6.2",
+        "lodash.padstart": "4.6.1",
+        "lodash.repeat": "4.1.0",
+        "sprintf-js": "1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha512-yaRZoAV3Xq28F1iafWN1+a0rflOej93l1DQUejs3SZ41h2O9UJBoS9aueGjPDgAl4B6tPC0NuuchLKaDQQ3Isg=="
+    },
+    "node_modules/lodash.max": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.max/-/lodash.max-4.0.1.tgz",
+      "integrity": "sha512-iykTDTb7PK33HSQmKy34zv+hh4WEu7WonJPXQcgODzUbbtradtNs8RsD/GI7XV++60KaKR1xhW56N4ISqHesfQ=="
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
+    },
+    "node_modules/lodash.padstart": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
+      "integrity": "sha512-sW73O6S8+Tg66eY56DBk85aQzzUJDtpoXFBgELMd5P/SotAguo+1kYO6RuYgXxA4HJH3LFTFPASX6ET6bjfriw=="
+    },
+    "node_modules/lodash.repeat": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/lodash.repeat/-/lodash.repeat-4.1.0.tgz",
+      "integrity": "sha512-eWsgQW89IewS95ZOcr15HHCX6FVDxq3f2PNUIng3fyzsPev9imFQxIYdFZ6crl8L56UR6ZlGDLcEb3RZsCSSqw=="
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg=="
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+      "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    }
+  }
+}

--- a/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/package.json
+++ b/pre-issue-access-token-extension-samples/adaptive-token-issuance-policy-service-aws-lambda/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "adaptive-token-issuance-policy",
+  "version": "1.0.0",
+  "description": "This sample demonstrates how to implement an **adaptive access token issuance policy** using a **Pre-Issue Access Token Extension**.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "geoip-country": "^5.0.202504292342"
+  }
+}

--- a/pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina/Ballerina.toml
+++ b/pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina/Ballerina.toml
@@ -1,0 +1,5 @@
+[package]
+org = "wso2"
+name = "extensions.asgardeo"
+version = "0.1.0"
+distribution = "2201.9.0"

--- a/pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina/README.md
+++ b/pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina/README.md
@@ -1,0 +1,162 @@
+# M2M Scope Limiting Policy 
+
+This is a Ballerina-based service hosted on Choreo that enforces strict scope control for machine-to-machine (M2M) access tokens. It limits the scopes in authorized tokens to `read:metrics` when issued using the client credentials grant, regardless of the application's full scope authorization.
+
+> **Note:** This sample is for demonstration only and should not be used in production. It supports the **Pre-issue access token action feature** of both [Asgardeo](https://console.asgardeo.io/) and [WSO2 Identity Server](https://wso2.com/identity-server/).
+
+## Table of Contents
+- [Overview](#overview)
+- [Scenario](#scenario)
+- [Prerequisites](#prerequisites)
+- [Setup Instructions](#setup-instructions)
+  - [1️⃣ Fork the Repository](#1-fork-the-repository)
+  - [2️⃣ Create a Component in Choreo](#4-create-a-component-in-choreo)
+  - [3️⃣ Deploy the Component](#4-deploy-the-component)
+- [Configure the Extension](#7-configure-the-extension)
+  - [1️⃣ Create an Appliction](#1-create-an-application)
+  - [2️⃣ Register API Resources](#1-register-api-resources)
+  - [3️⃣ Authorize the Application](#1-authorize-the-application)
+  - [4️⃣ Set Up Pre-Issue Access Token Action](#1-setup-pre-issue-access-token-action)
+- [Test the Service](#test-the-service)
+
+## Overview
+
+This service enforces strict scope control for M2M tokens issued via the client credentials grant. It supports:
+- Limiting token scopes to `read:metrics` only
+- Filtering out all other authorized scopes at token issuance time
+- Default behavior passthrough for other grant types
+
+## Scenario
+
+You have an application in Asgardeo that is allowed to request a wide range of scopes for internal service access:
+
+- `read:metrics`  
+- `write:alerts`  
+- `read:users`  
+- `write:config`
+
+While these scopes are all authorized at the app level, you want to **restrict M2M tokens (i.e., tokens obtained via `client_credentials` grant type)** so that only the `read:metrics` scope is permitted. This is common in analytics/reporting services where a background job should not access sensitive config or user data.
+
+When an access token is requested using the **client credentials** grant type:
+
+- All scopes **except** `read:metrics` are **removed**.
+- Only the `read:metrics` scope is retained in the final access token.
+- For all other grant types, the token issuance proceeds without modification.
+
+## Prerequisites
+
+Make sure you have the following installed and configured before deploying the service:
+  
+- A **GitHub account** connected to [Choreo Console](https://console.choreo.dev)
+
+- Access to **Choreo Console** to deploy and manage your service
+
+- _(Optional)_ A **Choreo API key** if you plan to secure the endpoint using API key authentication
+
+## Setup Instructions
+
+### 1. Fork the Repository in Github
+
+Fork this repository to your Github account.
+
+[← Back to Table of Contents](#table-of-contents)
+
+### 2. Create a Component in Choreo
+
+Log in to [Choreo Console](https://console.choreo.dev).
+
+Click **+ +Create** under **Component Listing**.
+
+Select **Service** as type.
+
+Select **Authorize with Github** under **Connect a Git Repository**.
+
+Select the forked repository and **main** branch.
+
+Set `pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina` as the **Component Directory**.
+
+Select **Ballerina** under **Build Presets**.
+
+Click **Create**.
+
+Wait for the build action to complete.
+
+[← Back to Table of Contents](#table-of-contents)
+
+### 3. Deploy the Component
+
+Navigate to the **Deploy** tab.
+
+Configure & Deploy to Development.
+
+Promote to Production.
+
+## Configure the Extension
+
+### 1. Create an Application
+
+Navigate to **Applications** → **New Application** in the Console application in Asgardeo or the WSO2 Identity Server.
+
+Select **Standard-Based Application**.
+
+Provide the following details:
+- **Name**: `M2M Scope Limiting Policy Demo App`
+- **Protocol**: OpenID Connect
+- **Grant Types**: Enable `Authorization Code` and `Client Credentials`.
+
+Save the application.
+
+### 2. Register API Resources
+
+Create the following resources with associated scopes:
+
+| Resource Name   | Scopes                     |
+|-----------------|----------------------------|
+| Metrics API     | `read:metrics`             |
+| Alerts API      | `write:alerts`             |
+| Users API       | `read:users`               |
+| Config API      | `write:config`             |
+
+### 3. Authorize the Application
+
+1. Go back to the application.
+2. Under **API Authorization**, click **+ Authorize API**.
+3. For each of the created API resources, **authorize all available scopes**.
+
+Your application is now allowed to request a **broad set of scopes**, but your Pre-Issue Access Token Extension will enforce the `read:metrics` scope restriction when the client uses the `client_credentials` grant.
+
+### 4. Set Up Pre-Issue Access Token Action
+
+Navigate to **Actions** → **Pre-Issue Access Token**.
+
+Create a new action:
+- **Action Name**: `M2M Scope Limiter`.
+- **Endpoint URL**: Use your Choreo HTTPS URL (e.g., `https://m2m-scope-limiter--<org>.apps.choreo.dev/filter`).
+- (Optional) Enable authentication and configure a secret if using an API key.
+
+Save the changes.
+
+[← Back to Table of Contents](#table-of-contents)
+
+## Test the Service
+
+You can test the policy using the **token endpoint** in Asgardeo. Use `curl` or Postman to simulate token requests with different scopes.
+
+
+| **Scenario**                     | **Expected Result**                              |
+|-----------------------------------|-------------------------------------------------|
+| Grant type is not `client_credentials` | Token is issued without modification.         |
+| Grant type is `client_credentials` with allowed scope (`read:metrics`) | Token is issued with the scope intact.        |
+| Grant type is `client_credentials` with disallowed scopes | Disallowed scopes are removed from the token. |
+
+Replace placeholders with actual values:
+
+```bash
+curl -X POST https://api.asgardeo.io/t/<tenant>/oauth2/token \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -u "<client_id>:<client_secret>" \
+  -d "grant_type=client_credentials" \
+  -d "scope=read:metrics write:users"
+```
+
+[← Back to Table of Contents](#table-of-contents)

--- a/pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina/main.bal
+++ b/pre-issue-access-token-extension-samples/m2m-scope-limiting-policy-service-ballerina/main.bal
@@ -1,0 +1,83 @@
+import ballerina/http;
+import ballerina/log;
+
+service / on new http:Listener(9090) {
+
+    resource function post filter(http:Caller caller, http:Request req) returns error? {
+
+        json bodyJson = check req.getJsonPayload();
+        log:printInfo("Received request payload: " + bodyJson.toJsonString());
+
+        map<json> body = <map<json>>bodyJson;
+
+        string actionType = body["actionType"].toString();
+        log:printInfo("Action type: " + actionType);
+
+        map<json> event = <map<json>> body["event"];
+        map<json> request = <map<json>> event["request"];
+        string grantType = request["grantType"].toString();
+        log:printInfo("Grant type: " + grantType);
+
+        map<json> accessToken = <map<json>> event["accessToken"];
+        json[] existingScopes = <json[]> accessToken["scopes"];
+        log:printInfo("Existing scopes: " + existingScopes.toString());
+
+        string CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
+        string ALLOWED_SCOPE = "read:metrics";
+
+        if actionType != "PRE_ISSUE_ACCESS_TOKEN" || grantType == "" {
+            log:printError("Invalid or missing actionType or grantType");
+
+            json responseBody = {
+                actionStatus: "FAILED",
+                failureReason: "invalid_request",
+                failureDescription: "Invalid or missing clientId or actionType"
+            };
+            http:Response res = new;
+            res.statusCode = 200;
+            res.setJsonPayload(responseBody);
+            check caller->respond(res);
+            return;
+        }
+
+        if grantType == CLIENT_CREDENTIALS_GRANT_TYPE {
+            json[] operations = [];
+            int index = 0;
+
+            foreach var scope in existingScopes {
+                if scope.toString() != ALLOWED_SCOPE {
+                    string path = "/accessToken/scopes/" + index.toString();
+                    operations.push({
+                        op: "remove",
+                        path: path
+                    });
+                    log:printInfo("Removing unauthorized scope at: " + path);
+                }
+                index += 1;
+            }
+
+            json responseBody = {
+                actionStatus: "SUCCESS",
+                operations: operations
+            };
+            log:printInfo("Returning modified token response: " + responseBody.toJsonString());
+
+            http:Response res = new;
+            res.statusCode = 200;
+            res.setJsonPayload(responseBody);
+            check caller->respond(res);
+            return;
+        }
+
+        log:printInfo("Grant type is not client_credentials, allowing default token issuance");
+
+        // Default behavior
+        json responseBody = {
+            actionStatus: "SUCCESS"
+        };
+        http:Response res = new;
+        res.statusCode = 200;
+        res.setJsonPayload(responseBody);
+        check caller->respond(res);
+    }
+}


### PR DESCRIPTION
### Purpose

Introduces two Pre-Issue Access Token Extension samples

1. Adaptive token issuance policy (Node.js + AWS Lambda)

    Implements dynamic access token expiry adjustment based on:
    - Geo-compliance (blocks tokens from restricted regions like KP, IR, etc.)
    - IP risk analysis (via [AbuseIPDB](https://www.abuseipdb.com/))
    - Time-of-day behavior (shorter token expiry during off-hours)

2. M2M Scope Limiting Policy (Choreo + Ballerina)

    Enforces strict scope policies for tokens issued via the client_credentials grant.
    Removes all scopes except read:metrics from the access token payload.

### Related Issue
- https://github.com/wso2-enterprise/iam-devrel/issues/97